### PR TITLE
fix(stock): format numeric values in variant dialog helper text

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -768,13 +768,16 @@ $.extend(erpnext.item, {
 			if (!row.disabled) {
 				if (row.numeric_values) {
 					fieldtype = "Float";
-					desc =
-						"Min Value: " +
-						row.from_range +
-						" , Max Value: " +
-						row.to_range +
-						", in Increments of: " +
-						row.increment;
+					let from = frappe.format_value(row.from_range, { fieldtype: "Float" });
+					let to = frappe.format_value(row.to_range, { fieldtype: "Float" });
+					let inc = frappe.format_value(row.increment, { fieldtype: "Float" });
+
+					desc = __("Min Value: {0}, Max Value: {1}, in Increments of: {2}", [
+						from,
+						to,
+						inc
+					]);
+
 				} else {
 					fieldtype = "Data";
 					desc = "";

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -768,9 +768,9 @@ $.extend(erpnext.item, {
 			if (!row.disabled) {
 				if (row.numeric_values) {
 					fieldtype = "Float";
-					let from = frappe.format_value(row.from_range, { fieldtype: "Float" });
-					let to = frappe.format_value(row.to_range, { fieldtype: "Float" });
-					let inc = frappe.format_value(row.increment, { fieldtype: "Float" });
+					let from = frappe.format(row.from_range, { fieldtype: "Float" }, { always_show_decimals: true });
+					let to = frappe.format(row.to_range, { fieldtype: "Float" }, { always_show_decimals: true });
+					let inc = frappe.format(row.increment, { fieldtype: "Float" }, { always_show_decimals: true });
 
 					desc = __("Min Value: {0}, Max Value: {1}, in Increments of: {2}", [
 						from,


### PR DESCRIPTION
### Summary

- Used `frappe.format_value` to ensure numeric values in the **Create Variant** dialog
  respect the System Settings Number Format.
- Updated `show_single_variant_dialog` in `item.js`.
- Fixes #49650

### Problem

Currently, when creating a variant from a template, the helper text under numeric
fields (Min, Max, Increment) shows raw DB values, ignoring the Number Format set in
System Settings. This leads to inconsistent number formatting across the system.

### Solution

Wrapped the numeric values (`from_range`, `to_range`, `increment`) with
`frappe.format_value` before rendering them in the description.

### Impact

- Ensures consistency with global number formatting.
- Improves user experience, especially for regions with custom number formats
  (e.g., `#.###,##`).
